### PR TITLE
GH Actions for PR and Release artifacts

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,105 @@
+name: Create Release
+
+# Create XCFramework when a version is tagged
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  create_release:
+    name: Create Release
+    runs-on: macos-latest
+    steps:
+
+    # Checkout the repository
+    - uses: actions/checkout@v2
+
+    # Build the XCFramework
+    - name: Create XCFramework
+      uses: unsignedapps/swift-create-xcframework@v2
+
+    # Create a zip file of the XCFramework
+    - name: Create ZIP
+      run: zip -r ${{ steps.create_xcframework.outputs.xcframework_name }} ${{ steps.create_xcframework.outputs.xcframework_path }}
+
+    # Create a changelog
+    - name: Create Changelog
+      uses: unsignedapps/swift-create-changelog@v2
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    # Create a release
+    - name: Create Release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        body: |
+          Changelog:
+          ${{ steps.changelog.outputs.changelog }}
+        draft: true
+        prerelease: ${{ github.tag_name.contains('beta') }}
+
+    # Upload the XCFramework ZIP to the release
+    - name: Upload XCFramework
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ steps.create_zip.outputs.xcframework_path }}
+        asset_name: ${{ steps.create_zip.outputs.xcframework_name }}
+        asset_content_type: application/zip
+
+    # Upload the changelog to the release
+    - name: Upload Changelog
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ steps.changelog.outputs.changelog_path }}
+        asset_name: Changelog.md
+        asset_content_type: text/markdown
+
+    # Notify Discord
+    - name: Discord Notify
+      uses: stegzilla/discord-notify@v4
+      with:
+        webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        title: New SideKit release created
+        message: |
+          A new release has been created: ${{ github.ref }}
+          Changelog:
+          ${{ steps.changelog.outputs.changelog }}
+          XCFramework Zip:
+          ${{ steps.create_zip.outputs.xcframework_name }}
+        include_image: true
+        username: GitHub Actions
+        avatar_url: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+        color: 0x2cbe4e
+
+    # # Notify Discord
+    # - name: Notify Discord
+    #   uses: Ilshidur/action-discord@v2
+    #   with:
+    #     args: |
+    #       A new release has been created: ${{ github.ref }}
+    #       Changelog:
+    #       ${{ steps.changelog.outputs.changelog }}
+    #       XCFramework Zip:
+    #       ${{ steps.create_zip.outputs.xcframework_name }}
+    #   env:
+    #     DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+
+    # with:
+    #   webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+    #   message: |
+    #     A new release has been created: ${{ github.ref }}
+    #     Changelog:
+    #     ${{ steps.changelog.outputs.changelog }}
+    #   username: GitHub Actions
+    #   avatar_url: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+    #   color: 0x2cbe4e

--- a/.github/workflows/pr_comment_build_artifcats.yml
+++ b/.github/workflows/pr_comment_build_artifcats.yml
@@ -1,0 +1,22 @@
+name: Add artifact links to pull request and related issues
+
+on:
+  workflow_run:
+    workflows: [Unit Test and Build]
+    types: [completed]
+
+jobs:
+  artifacts-url-comments:
+    name: add artifact links to pull request and related issues job
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+    - name: add artifact links to pull request and related issues step
+      uses: tonyhallett/artifacts-url-comments@v1.1.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        prefix: Builds for this Pull Request are available at
+        suffix: Have a nice day.
+        format: name
+        addTo: pullandissues

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,47 +1,72 @@
-name: Unit Test
+name: Unit Test and Build
 
 on:
   pull_request:
     paths:
-      - "**.swift"
-      - "**.xcodeproj"
-      - "**.m"
-      - "**.h"
-      - "**.podspec"
-      - "Podfile"
-      - "Podfile.lock"
-      - "test.yml"
+    - "**.swift"
+    - "**.xcodeproj"
+    - "**.m"
+    - "**.h"
+    - "**.podspec"
+    - "Podfile"
+    - "Podfile.lock"
+    - "test.yml"
 jobs:
   swiftpm:
     name: Test iOS (swiftpm)
-    runs-on: macOS-latest
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
+    runs-on: macos-latest
+    # env:
+    #   DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
     steps:
-      - name: Checkout
-        uses: actions/checkout@master
 
-      - name: iOS - Swift PM
-        run: |
-          set -o pipefail && swift test --parallel | xcpretty -c --test --color --report junit --output build/reports/junit.xml --report html --output build/reports/html
+    # Checkout the repository
+    - name: Checkout
+      uses: actions/checkout@master
 
-      - name: Upload Test Results
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: Test Results
-          path: build/reports
+    # Swift test
+    - name: iOS - Swift PM
+      run: |
+        set -o pipefail && swift test --parallel | xcpretty -c --test --color --report junit --output build/reports/junit.xml --report html --output build/reports/html
 
-      - name: Upload Coverage Results
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: Coverage Results
-          path: build/coverage
+    # Upload Test Results
+    - name: Upload Test Results
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: Test Results
+        path: build/reports
 
-      - name: Upload Logs
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: Logs
-          path: build/logs
+    # Upload Coverage Results
+    - name: Upload Coverage Results
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: Coverage Results
+        path: build/coverage
+
+    # Upload the logs
+    - name: Upload Logs
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: Logs
+        path: build/logs
+
+    # Build the XCFramework
+    - name: Create XCFramework
+      uses: unsignedapps/swift-create-xcframework@v2
+
+    - name: Create ZIP
+      # Create a zip file of the XCFramework
+      run: zip -r ${{ steps.create_xcframework.outputs.xcframework_name }} ${{ steps.create_xcframework.outputs.xcframework_path }}
+
+    # Attach build artifachts to the workflow run
+    - name: Attach build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Build Artifacts
+        path: |
+          ${{ steps.create_zip.outputs.xcframework_path }}
+          ${{ steps.create_zip.outputs.xcframework_name }}
+          # ${{ steps.create_xcframework.outputs.xcframework_path }}
+          # ${{ steps.create_xcframework.outputs.xcframework_name }}


### PR DESCRIPTION
Similar to SideStore and Proveance this should "in theory" 

- test then build xcframework on PRs 
- same action as SideStore then comments on the PR 
- A new workflow for creating releases on tag pushes. If it has the string Beta, it makes a pre-release. 

They're set to draft. It should also create a changelog and attach and comment that to the release, and finally ping discord (need to setup webhook key in github secrets)

---

Like all new GH Actions Prs, this will probably take some messing with before it's done / working as wanted.